### PR TITLE
Resolved Pywalfox not found error when launching from hyprland keybind

### DIFF
--- a/src/services/ThemeGenerator.js
+++ b/src/services/ThemeGenerator.js
@@ -527,36 +527,41 @@ export class ThemeGenerator {
 
     // Upadte Pywalfox to Sync Firefox Theme
     _updatePywalfox() {
-        // Get the user's home directory dynamically
-        const homeDir = GLib.get_home_dir();
-        const possiblePaths = [
-            '/usr/bin/pywalfox',
-            '/usr/local/bin/pywalfox',
-            `${homeDir}/.local/bin/pywalfox`
-        ];
-
-        let binaryPath = 'pywalfox'; // Default fallback
-
-        // Find the first path that actually exists
-        for (const path of possiblePaths) {
-            if (Gio.File.new_for_path(path).query_exists(null)) {
-                binaryPath = path;
-                break;
-            }
-        }
-
         try {
-            print(`Updating Firefox via: ${binaryPath}`);
+            // 1. Search for the binary in a way that doesn't care about the shell
+            let pywalfoxPath = GLib.find_program_in_path('pywalfox');
+
+            // 2. If it's not in the standard PATH, check common user-local paths manually
+            if (!pywalfoxPath) {
+                const home = GLib.get_home_dir();
+                const localPath = `${home}/.local/bin/pywalfox`;
+                if (Gio.File.new_for_path(localPath).query_exists(null)) {
+                    pywalfoxPath = localPath;
+                }
+            }
+
+            if (!pywalfoxPath) {
+                print('Tema: pywalfox not found. Skipping Firefox update.');
+                return;
+            }
+
+            // 3. Execute directly using the absolute path (No shell required!)
             const proc = new Gio.Subprocess({
-                argv: [binaryPath, 'update'],
+                argv: [pywalfoxPath, 'update'],
                 flags: Gio.SubprocessFlags.NONE,
             });
+
             proc.init(null);
             proc.wait_async(null, (p, r) => {
-                try { p.wait_finish(r); } catch (e) {}
+                try {
+                    p.wait_finish(r);
+                    print('Tema: Firefox theme updated.');
+                } catch (e) {
+                    print('Tema: Pywalfox execution failed:', e.message);
+                }
             });
         } catch (error) {
-            print('Pywalfox launch failed:', error.message);
+            print('Tema: Error in _updatePywalfox:', error.message);
         }
     }
 }

--- a/src/services/ThemeGenerator.js
+++ b/src/services/ThemeGenerator.js
@@ -528,40 +528,23 @@ export class ThemeGenerator {
     // Upadte Pywalfox to Sync Firefox Theme
     _updatePywalfox() {
         try {
-            // 1. Search for the binary in a way that doesn't care about the shell
-            let pywalfoxPath = GLib.find_program_in_path('pywalfox');
-
-            // 2. If it's not in the standard PATH, check common user-local paths manually
-            if (!pywalfoxPath) {
-                const home = GLib.get_home_dir();
-                const localPath = `${home}/.local/bin/pywalfox`;
-                if (Gio.File.new_for_path(localPath).query_exists(null)) {
-                    pywalfoxPath = localPath;
-                }
-            }
-
-            if (!pywalfoxPath) {
-                print('Tema: pywalfox not found. Skipping Firefox update.');
-                return;
-            }
-
-            // 3. Execute directly using the absolute path (No shell required!)
-            const proc = new Gio.Subprocess({
-                argv: [pywalfoxPath, 'update'],
+            print('Updating Firefox theme via Pywalfox...');
+            const pywalfoxProcess = new Gio.Subprocess({
+                argv: ['pywalfox', 'update'],
                 flags: Gio.SubprocessFlags.NONE,
             });
-
-            proc.init(null);
-            proc.wait_async(null, (p, r) => {
+            pywalfoxProcess.init(null);
+            // We use wait_async so it doesn't freeze your UI while updating
+            pywalfoxProcess.wait_async(null, (proc, res) => {
                 try {
-                    p.wait_finish(r);
-                    print('Tema: Firefox theme updated.');
+                    proc.wait_finish(res);
+                    print('Pywalfox update complete!');
                 } catch (e) {
-                    print('Tema: Pywalfox execution failed:', e.message);
+                    print('Pywalfox update failed:', e.message);
                 }
             });
         } catch (error) {
-            print('Tema: Error in _updatePywalfox:', error.message);
+            print('Error launching pywalfox:', error.message);
         }
     }
 }

--- a/src/services/ThemeGenerator.js
+++ b/src/services/ThemeGenerator.js
@@ -527,24 +527,36 @@ export class ThemeGenerator {
 
     // Upadte Pywalfox to Sync Firefox Theme
     _updatePywalfox() {
+        // Get the user's home directory dynamically
+        const homeDir = GLib.get_home_dir();
+        const possiblePaths = [
+            '/usr/bin/pywalfox',
+            '/usr/local/bin/pywalfox',
+            `${homeDir}/.local/bin/pywalfox`
+        ];
+
+        let binaryPath = 'pywalfox'; // Default fallback
+
+        // Find the first path that actually exists
+        for (const path of possiblePaths) {
+            if (Gio.File.new_for_path(path).query_exists(null)) {
+                binaryPath = path;
+                break;
+            }
+        }
+
         try {
-            print('Updating Firefox theme via Pywalfox...');
-            const pywalfoxProcess = new Gio.Subprocess({
-                argv: ['pywalfox', 'update'],
+            print(`Updating Firefox via: ${binaryPath}`);
+            const proc = new Gio.Subprocess({
+                argv: [binaryPath, 'update'],
                 flags: Gio.SubprocessFlags.NONE,
             });
-            pywalfoxProcess.init(null);
-            // We use wait_async so it doesn't freeze your UI while updating
-            pywalfoxProcess.wait_async(null, (proc, res) => {
-                try {
-                    proc.wait_finish(res);
-                    print('Pywalfox update complete!');
-                } catch (e) {
-                    print('Pywalfox update failed:', e.message);
-                }
+            proc.init(null);
+            proc.wait_async(null, (p, r) => {
+                try { p.wait_finish(r); } catch (e) {}
             });
         } catch (error) {
-            print('Error launching pywalfox:', error.message);
+            print('Pywalfox launch failed:', error.message);
         }
     }
 }

--- a/src/services/ThemeGenerator.js
+++ b/src/services/ThemeGenerator.js
@@ -529,8 +529,10 @@ export class ThemeGenerator {
     _updatePywalfox() {
         try {
             print('Updating Firefox theme via Pywalfox...');
+            // We use bash -c with an explicit mise activation because login shells
+            // often return early in non-interactive environments, skipping the mise setup.
             const pywalfoxProcess = Gio.Subprocess.new(
-                ['bash', '-l', '-c', 'pywalfox update'],
+                ['bash', '-c', 'eval "$(mise activate bash 2>/dev/null)" || true; pywalfox update'],
                 Gio.SubprocessFlags.NONE
             );
             // We use wait_check_async so it doesn't freeze your UI while updating

--- a/src/services/ThemeGenerator.js
+++ b/src/services/ThemeGenerator.js
@@ -525,19 +525,19 @@ export class ThemeGenerator {
         return dialog;
     }
 
-    // Upadte Pywalfox to Sync Firefox Theme
+    // Update Pywalfox to Sync Firefox Theme
     _updatePywalfox() {
         try {
             print('Updating Firefox theme via Pywalfox...');
-            const pywalfoxProcess = new Gio.Subprocess({
-                argv: ['pywalfox', 'update'],
-                flags: Gio.SubprocessFlags.NONE,
-            });
-            pywalfoxProcess.init(null);
-            // We use wait_async so it doesn't freeze your UI while updating
-            pywalfoxProcess.wait_async(null, (proc, res) => {
+            const pywalfoxProcess = Gio.Subprocess.new(
+                ['bash', '-l', '-c', 'pywalfox update'],
+                Gio.SubprocessFlags.NONE
+            );
+            // We use wait_check_async so it doesn't freeze your UI while updating
+            // and we can properly detect if the command failed (non-zero exit code)
+            pywalfoxProcess.wait_check_async(null, (proc, res) => {
                 try {
-                    proc.wait_finish(res);
+                    proc.wait_check_finish(res);
                     print('Pywalfox update complete!');
                 } catch (e) {
                     print('Pywalfox update failed:', e.message);


### PR DESCRIPTION
## Details
When built locally and run from the terminal, Tema worked as usual and `pywalfox` would run successfully to sync Firefox themes. When run using a hyprland keybind `pywalfox` could not be found. This PR addresses allowing tema to search for the location of pywalfox before it runs the update command to ensure that it can update successfully.

## Changes
- reworked _updatePywalfox() in ThemeGenerator.js to find pywalfox installation and ensure it is accessible to the script